### PR TITLE
fix(heartHP):Use the correct range instead of betweeen

### DIFF
--- a/ohif-configurable/hp-extension/package.json
+++ b/ohif-configurable/hp-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@radicalimaging/hp-extension",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "description": "Extension to define support for basic MPR",
   "author": "Bill Wallace",
   "license": "MIT",

--- a/ohif-configurable/hp-extension/src/hp/hpHeart.ts
+++ b/ohif-configurable/hp-extension/src/hp/hpHeart.ts
@@ -1,11 +1,7 @@
 export default {
   id: 'LV Function Heart',
   hasUpdatedPriorsInformation: false,
-  name: 'Default',
-  createdDate: '2021-02-23T19:22:08.894Z',
-  modifiedDate: '2021-02-23T19:22:08.894Z',
-  availableTo: {},
-  editableBy: {},
+  name: 'LV Function Heart',
   protocolMatchingRules: [
     {
       id: 'MR',
@@ -62,7 +58,7 @@ export default {
               weight: 1,
               attribute: 'numImageFrames',
               constraint: {
-                betweeen: {
+                range: {
                   value: [20, 40],
                 },
               },
@@ -91,7 +87,7 @@ export default {
               id: 'numImageFrames>25',
               attribute: 'numImageFrames',
               constraint: {
-                betweeen: {
+                range: {
                   value: [20, 40],
                 },
               },
@@ -121,7 +117,7 @@ export default {
               id: 'numImageFrames>25',
               attribute: 'numImageFrames',
               constraint: {
-                betweeen: {
+                range: {
                   value: [20, 40],
                 },
               },
@@ -151,7 +147,7 @@ export default {
               id: 'numImageFrames>25',
               attribute: 'numImageFrames',
               constraint: {
-                betweeen: {
+                range: {
                   value: [20, 40],
                 },
               },

--- a/ohif-configurable/hp-extension/src/synchronizers/createSingleViewportSynchronizer.ts
+++ b/ohif-configurable/hp-extension/src/synchronizers/createSingleViewportSynchronizer.ts
@@ -20,9 +20,7 @@ function add(viewportInfo) {
     this.setOptions(viewportId, { viewportInfo });
     return;
   }
-  options.viewportInfo = viewportInfo;
-  
-  console.log("Add viewport info called for", viewportId);
+  options.viewportInfo = viewportInfo;  
 }
 
 function addEvent(eventName, listener) {

--- a/ohif-configurable/hp-mode/package.json
+++ b/ohif-configurable/hp-mode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@radicalimaging/hp-mode",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "description": "Apply hanging protocols to longitudinal mode",
   "author": "Bill Wallace and Radical Imaging",
   "license": "MIT",

--- a/ohif-configurable/hp-mode/src/index.tsx
+++ b/ohif-configurable/hp-mode/src/index.tsx
@@ -11,7 +11,7 @@ import ConfigPoint from 'config-point';
 
 const extensionDependencies = {
   ...defaultExtensions,
-  '@radicalimaging/hp-extension': '^3.3.1',
+  '@radicalimaging/hp-extension': '^3.3.2',
 };
 
 function modeFactory({ modeConfiguration }) {


### PR DESCRIPTION
@ladeirarodolfo - could you look at this change?  Very simply use the range command instead of betweeen.  I have a todo to make it obvious when the hanging protocols aren't correctly matching, but that isn't the fault of the hanging protocol, but is a service level change.