### PR TITLE
fix(initialZoomPan):isNan(pan) fix blank screen

### DIFF
--- a/ohif-configurable/hp-extension/package.json
+++ b/ohif-configurable/hp-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@radicalimaging/hp-extension",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "description": "Extension to define support for basic MPR",
   "author": "Bill Wallace",
   "license": "MIT",

--- a/ohif-configurable/hp-extension/src/synchronizers/initialZoomPanCallback.ts
+++ b/ohif-configurable/hp-extension/src/synchronizers/initialZoomPanCallback.ts
@@ -41,10 +41,13 @@ export default function initialPanZoomCallback(
   const imageWidth = dimensionsCanvas[1] - zeroCanvas[1];
   const panX = (screenX - 0.5) * screenWidth + (0.5 - imageX) * imageWidth;
   const panY = (screenY - 0.5) * screenHeight + (0.5 - imageY) * imageHeight;
-  sViewport.setPan([panX, panY], true);
+  if( isFinite(panX) && isFinite(panY) ) {
+    sViewport.setPan([panX, panY], true);
+  }
 
   const { pan, zoom: previousZoom } = options;
   // These are non-default initial values here, so don't pass true to reset
+  // Values have been checked before assigning, so safe to just assign here.
   if( previousZoom ) sViewport.setZoom(previousZoom);
   if( pan ) sViewport.setPan(pan);
 }
@@ -62,6 +65,9 @@ export function storeCurrentZoomPan(synchronizerInstance: Synchronizer,  viewpor
   if (!options) return;
 
   const sViewport = renderingEngine.getViewport(viewportId);
-  options.pan = sViewport.getPan();
-  options.zoom = sViewport.getZoom();
+  const pan = sViewport.getPan();
+  if( pan && isFinite(pan[0]) && isFinite(pan[1]) ) {
+    options.pan = pan;
+    options.zoom = sViewport.getZoom();
+  }
 }

--- a/ohif-configurable/hp-mode/package.json
+++ b/ohif-configurable/hp-mode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@radicalimaging/hp-mode",
-  "version": "3.3.3",
+  "version": "3.3.4",
   "description": "Apply hanging protocols to longitudinal mode",
   "author": "Bill Wallace and Radical Imaging",
   "license": "MIT",

--- a/ohif-configurable/hp-mode/src/index.tsx
+++ b/ohif-configurable/hp-mode/src/index.tsx
@@ -11,7 +11,7 @@ import ConfigPoint from 'config-point';
 
 const extensionDependencies = {
   ...defaultExtensions,
-  '@radicalimaging/hp-extension': '^3.3.2',
+  '@radicalimaging/hp-extension': '^3.3.3',
 };
 
 function modeFactory({ modeConfiguration }) {


### PR DESCRIPTION
Sometimes the pan returns isNaN on both values, particularly when something is hidden before storing the previous pan values.  This change fixes it by avoiding storing the values initially.
@ladeirarodolfo 