### PR TITLE
Rewrote `dicom-html` extension from OHIFv2 to v3

### DIFF
--- a/extensions/dicom-html/.webpack/webpack.dev.js
+++ b/extensions/dicom-html/.webpack/webpack.dev.js
@@ -1,0 +1,8 @@
+const path = require('path');
+const webpackCommon = require('./../../../.webpack/webpack.commonjs.js');
+const SRC_DIR = path.join(__dirname, '../src');
+const DIST_DIR = path.join(__dirname, '../dist');
+
+module.exports = (env, argv) => {
+  return webpackCommon(env, argv, { SRC_DIR, DIST_DIR });
+};

--- a/extensions/dicom-html/.webpack/webpack.prod.js
+++ b/extensions/dicom-html/.webpack/webpack.prod.js
@@ -1,0 +1,44 @@
+const webpack = require('webpack');
+const merge = require('webpack-merge');
+const path = require('path');
+const webpackCommon = require('./../../../.webpack/webpack.commonjs.js');
+const pkg = require('./../package.json');
+
+const ROOT_DIR = path.join(__dirname, './..');
+const SRC_DIR = path.join(__dirname, '../src');
+const DIST_DIR = path.join(__dirname, '../dist');
+
+module.exports = (env, argv) => {
+  const commonConfig = webpackCommon(env, argv, { SRC_DIR, DIST_DIR });
+
+  return merge(commonConfig, {
+    devtool: 'source-map',
+    stats: {
+      colors: true,
+      hash: true,
+      timings: true,
+      assets: true,
+      chunks: false,
+      chunkModules: false,
+      modules: false,
+      children: false,
+      warnings: true,
+    },
+    optimization: {
+      minimize: true,
+      sideEffects: true,
+    },
+    output: {
+      path: ROOT_DIR,
+      library: 'OHIFExtDicomHtml',
+      libraryTarget: 'umd',
+      libraryExport: 'default',
+      filename: pkg.main,
+    },
+    plugins: [
+      new webpack.optimize.LimitChunkCountPlugin({
+        maxChunks: 1,
+      }),
+    ],
+  });
+};

--- a/extensions/dicom-html/CHANGELOG.md
+++ b/extensions/dicom-html/CHANGELOG.md
@@ -1,0 +1,523 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+
+## [3.0.0]() (2022-09-24)
+
+Ported to be compatible with OHIF v3
+
+
+
+
+## [1.3.23](https://github.com/OHIF/Viewers/compare/@ohif/extension-dicom-html@1.3.22...@ohif/extension-dicom-html@1.3.23) (2022-09-01)
+
+**Note:** Version bump only for package @ohif/extension-dicom-html
+
+
+
+
+
+## [1.3.22](https://github.com/OHIF/Viewers/compare/@ohif/extension-dicom-html@1.3.21...@ohif/extension-dicom-html@1.3.22) (2022-06-30)
+
+**Note:** Version bump only for package @ohif/extension-dicom-html
+
+
+
+
+
+## [1.3.21](https://github.com/OHIF/Viewers/compare/@ohif/extension-dicom-html@1.3.20...@ohif/extension-dicom-html@1.3.21) (2022-04-05)
+
+**Note:** Version bump only for package @ohif/extension-dicom-html
+
+
+
+
+
+## [1.3.20](https://github.com/OHIF/Viewers/compare/@ohif/extension-dicom-html@1.3.19...@ohif/extension-dicom-html@1.3.20) (2022-03-25)
+
+**Note:** Version bump only for package @ohif/extension-dicom-html
+
+
+
+
+
+## [1.3.19](https://github.com/OHIF/Viewers/compare/@ohif/extension-dicom-html@1.3.18...@ohif/extension-dicom-html@1.3.19) (2022-03-14)
+
+**Note:** Version bump only for package @ohif/extension-dicom-html
+
+
+
+
+
+## [1.3.18](https://github.com/OHIF/Viewers/compare/@ohif/extension-dicom-html@1.3.17...@ohif/extension-dicom-html@1.3.18) (2022-02-03)
+
+**Note:** Version bump only for package @ohif/extension-dicom-html
+
+
+
+
+
+## [1.3.17](https://github.com/OHIF/Viewers/compare/@ohif/extension-dicom-html@1.3.16...@ohif/extension-dicom-html@1.3.17) (2022-02-03)
+
+**Note:** Version bump only for package @ohif/extension-dicom-html
+
+
+
+
+
+## [1.3.16](https://github.com/OHIF/Viewers/compare/@ohif/extension-dicom-html@1.3.15...@ohif/extension-dicom-html@1.3.16) (2022-02-02)
+
+**Note:** Version bump only for package @ohif/extension-dicom-html
+
+
+
+
+
+## [1.3.15](https://github.com/OHIF/Viewers/compare/@ohif/extension-dicom-html@1.3.14...@ohif/extension-dicom-html@1.3.15) (2022-01-20)
+
+**Note:** Version bump only for package @ohif/extension-dicom-html
+
+
+
+
+
+## [1.3.14](https://github.com/OHIF/Viewers/compare/@ohif/extension-dicom-html@1.3.13...@ohif/extension-dicom-html@1.3.14) (2021-12-02)
+
+**Note:** Version bump only for package @ohif/extension-dicom-html
+
+
+
+
+
+## [1.3.13](https://github.com/OHIF/Viewers/compare/@ohif/extension-dicom-html@1.3.12...@ohif/extension-dicom-html@1.3.13) (2021-10-26)
+
+**Note:** Version bump only for package @ohif/extension-dicom-html
+
+
+
+
+
+## [1.3.12](https://github.com/OHIF/Viewers/compare/@ohif/extension-dicom-html@1.3.11...@ohif/extension-dicom-html@1.3.12) (2021-10-25)
+
+**Note:** Version bump only for package @ohif/extension-dicom-html
+
+
+
+
+
+## [1.3.11](https://github.com/OHIF/Viewers/compare/@ohif/extension-dicom-html@1.3.10...@ohif/extension-dicom-html@1.3.11) (2021-09-28)
+
+**Note:** Version bump only for package @ohif/extension-dicom-html
+
+
+
+
+
+## [1.3.10](https://github.com/OHIF/Viewers/compare/@ohif/extension-dicom-html@1.3.9...@ohif/extension-dicom-html@1.3.10) (2021-06-02)
+
+
+### Bug Fixes
+
+* **dicom-html:** Add parsed dicom meta info section ([#2419](https://github.com/OHIF/Viewers/issues/2419)) ([403688b](https://github.com/OHIF/Viewers/commit/403688b18c52468fc1101166ec0c1734fb710039))
+
+
+
+
+
+## [1.3.9](https://github.com/OHIF/Viewers/compare/@ohif/extension-dicom-html@1.3.8...@ohif/extension-dicom-html@1.3.9) (2021-04-22)
+
+**Note:** Version bump only for package @ohif/extension-dicom-html
+
+
+
+
+
+## [1.3.8](https://github.com/OHIF/Viewers/compare/@ohif/extension-dicom-html@1.3.7...@ohif/extension-dicom-html@1.3.8) (2021-04-22)
+
+**Note:** Version bump only for package @ohif/extension-dicom-html
+
+
+
+
+
+## [1.3.7](https://github.com/OHIF/Viewers/compare/@ohif/extension-dicom-html@1.3.6...@ohif/extension-dicom-html@1.3.7) (2021-04-21)
+
+**Note:** Version bump only for package @ohif/extension-dicom-html
+
+
+
+
+
+## [1.3.6](https://github.com/OHIF/Viewers/compare/@ohif/extension-dicom-html@1.3.5...@ohif/extension-dicom-html@1.3.6) (2021-04-21)
+
+**Note:** Version bump only for package @ohif/extension-dicom-html
+
+
+
+
+
+## [1.3.5](https://github.com/OHIF/Viewers/compare/@ohif/extension-dicom-html@1.3.4...@ohif/extension-dicom-html@1.3.5) (2021-04-15)
+
+**Note:** Version bump only for package @ohif/extension-dicom-html
+
+
+
+
+
+## [1.3.4](https://github.com/OHIF/Viewers/compare/@ohif/extension-dicom-html@1.3.3...@ohif/extension-dicom-html@1.3.4) (2021-03-09)
+
+**Note:** Version bump only for package @ohif/extension-dicom-html
+
+
+
+
+
+## [1.3.3](https://github.com/OHIF/Viewers/compare/@ohif/extension-dicom-html@1.3.2...@ohif/extension-dicom-html@1.3.3) (2021-03-03)
+
+**Note:** Version bump only for package @ohif/extension-dicom-html
+
+
+
+
+
+## [1.3.2](https://github.com/OHIF/Viewers/compare/@ohif/extension-dicom-html@1.3.1...@ohif/extension-dicom-html@1.3.2) (2021-02-25)
+
+**Note:** Version bump only for package @ohif/extension-dicom-html
+
+
+
+
+
+## [1.3.1](https://github.com/OHIF/Viewers/compare/@ohif/extension-dicom-html@1.3.0...@ohif/extension-dicom-html@1.3.1) (2021-02-05)
+
+**Note:** Version bump only for package @ohif/extension-dicom-html
+
+
+
+
+
+# [1.3.0](https://github.com/OHIF/Viewers/compare/@ohif/extension-dicom-html@1.2.9...@ohif/extension-dicom-html@1.3.0) (2020-12-10)
+
+
+### Features
+
+* visualize overlapping segments in cornerstone ([#2185](https://github.com/OHIF/Viewers/issues/2185)) ([29fceac](https://github.com/OHIF/Viewers/commit/29fceacee97d51f1952a0f6b574c66596d32c201))
+
+
+
+
+
+## [1.2.9](https://github.com/OHIF/Viewers/compare/@ohif/extension-dicom-html@1.2.8...@ohif/extension-dicom-html@1.2.9) (2020-10-07)
+
+**Note:** Version bump only for package @ohif/extension-dicom-html
+
+
+
+
+
+## [1.2.8](https://github.com/OHIF/Viewers/compare/@ohif/extension-dicom-html@1.2.7...@ohif/extension-dicom-html@1.2.8) (2020-09-10)
+
+**Note:** Version bump only for package @ohif/extension-dicom-html
+
+
+
+
+
+## [1.2.7](https://github.com/OHIF/Viewers/compare/@ohif/extension-dicom-html@1.2.6...@ohif/extension-dicom-html@1.2.7) (2020-09-03)
+
+**Note:** Version bump only for package @ohif/extension-dicom-html
+
+
+
+
+
+## [1.2.6](https://github.com/OHIF/Viewers/compare/@ohif/extension-dicom-html@1.2.5...@ohif/extension-dicom-html@1.2.6) (2020-09-02)
+
+**Note:** Version bump only for package @ohif/extension-dicom-html
+
+
+
+
+
+## [1.2.5](https://github.com/OHIF/Viewers/compare/@ohif/extension-dicom-html@1.2.4...@ohif/extension-dicom-html@1.2.5) (2020-08-28)
+
+**Note:** Version bump only for package @ohif/extension-dicom-html
+
+
+
+
+
+## [1.2.4](https://github.com/OHIF/Viewers/compare/@ohif/extension-dicom-html@1.2.3...@ohif/extension-dicom-html@1.2.4) (2020-07-13)
+
+**Note:** Version bump only for package @ohif/extension-dicom-html
+
+
+
+
+
+## [1.2.3](https://github.com/OHIF/Viewers/compare/@ohif/extension-dicom-html@1.2.2...@ohif/extension-dicom-html@1.2.3) (2020-06-15)
+
+
+### Bug Fixes
+
+* 🐛 Disable seg panel when data for seg unavailable ([#1732](https://github.com/OHIF/Viewers/issues/1732)) ([698e900](https://github.com/OHIF/Viewers/commit/698e900b85121d3c2a46747c443ef69fb7a8c95b)), closes [#1728](https://github.com/OHIF/Viewers/issues/1728)
+
+
+
+
+
+## [1.2.2](https://github.com/OHIF/Viewers/compare/@ohif/extension-dicom-html@1.2.1...@ohif/extension-dicom-html@1.2.2) (2020-05-04)
+
+
+### Bug Fixes
+
+* 🐛 Proper error handling for derived display sets ([#1708](https://github.com/OHIF/Viewers/issues/1708)) ([5b20d8f](https://github.com/OHIF/Viewers/commit/5b20d8f323e4b3ef9988f2f2ab672d697b6da409))
+
+
+
+
+
+## [1.2.1](https://github.com/OHIF/Viewers/compare/@ohif/extension-dicom-html@1.2.0...@ohif/extension-dicom-html@1.2.1) (2020-04-28)
+
+**Note:** Version bump only for package @ohif/extension-dicom-html
+
+
+
+
+
+# [1.2.0](https://github.com/OHIF/Viewers/compare/@ohif/extension-dicom-html@1.1.2...@ohif/extension-dicom-html@1.2.0) (2020-04-24)
+
+
+### Features
+
+* 🎸 Seg jump to slice + show/hide ([835f64d](https://github.com/OHIF/Viewers/commit/835f64d47a9994f6a25aaf3941a4974e215e7e7f))
+
+
+
+
+
+## [1.1.2](https://github.com/OHIF/Viewers/compare/@ohif/extension-dicom-html@1.1.1...@ohif/extension-dicom-html@1.1.2) (2020-04-02)
+
+**Note:** Version bump only for package @ohif/extension-dicom-html
+
+
+
+
+
+## [1.1.1](https://github.com/OHIF/Viewers/compare/@ohif/extension-dicom-html@1.1.0...@ohif/extension-dicom-html@1.1.1) (2020-03-09)
+
+**Note:** Version bump only for package @ohif/extension-dicom-html
+
+
+
+
+
+# [1.1.0](https://github.com/OHIF/Viewers/compare/@ohif/extension-dicom-html@1.0.2...@ohif/extension-dicom-html@1.1.0) (2019-12-11)
+
+
+### Features
+
+* 🎸 DICOM SR STOW on MeasurementAPI ([#954](https://github.com/OHIF/Viewers/issues/954)) ([ebe1af8](https://github.com/OHIF/Viewers/commit/ebe1af8d4f75d2483eba869655906d7829bd9666)), closes [#758](https://github.com/OHIF/Viewers/issues/758)
+
+
+
+
+
+## [1.0.2](https://github.com/OHIF/Viewers/compare/@ohif/extension-dicom-html@1.0.1...@ohif/extension-dicom-html@1.0.2) (2019-12-02)
+
+**Note:** Version bump only for package @ohif/extension-dicom-html
+
+
+
+
+
+## [1.0.1](https://github.com/OHIF/Viewers/compare/@ohif/extension-dicom-html@1.0.0...@ohif/extension-dicom-html@1.0.1) (2019-10-29)
+
+
+### Bug Fixes
+
+* Set SR viewport as active by interaction ([#1118](https://github.com/OHIF/Viewers/issues/1118)) ([5b33417](https://github.com/OHIF/Viewers/commit/5b334175c370afb930b4b6dbd307ddece8f850e3))
+
+
+
+
+
+# [1.0.0](https://github.com/OHIF/Viewers/compare/@ohif/extension-dicom-html@0.50.8...@ohif/extension-dicom-html@1.0.0) (2019-09-27)
+
+
+### Bug Fixes
+
+* 🐛 Add DicomLoaderService & FileLoaderService to fix SR, PDF, and SEG support in local file and WADO-RS-only use cases ([#862](https://github.com/OHIF/Viewers/issues/862)) ([e7e1a8a](https://github.com/OHIF/Viewers/commit/e7e1a8a)), closes [#838](https://github.com/OHIF/Viewers/issues/838)
+
+
+### BREAKING CHANGES
+
+* DICOM Seg
+
+
+
+
+
+## [0.50.8](https://github.com/OHIF/Viewers/compare/@ohif/extension-dicom-html@0.50.7...@ohif/extension-dicom-html@0.50.8) (2019-09-26)
+
+
+### Bug Fixes
+
+* Add some code splitting for PWA build ([#937](https://github.com/OHIF/Viewers/issues/937)) ([8938035](https://github.com/OHIF/Viewers/commit/8938035))
+
+
+
+
+
+## [0.50.7](https://github.com/OHIF/Viewers/compare/@ohif/extension-dicom-html@0.50.6...@ohif/extension-dicom-html@0.50.7) (2019-09-12)
+
+**Note:** Version bump only for package @ohif/extension-dicom-html
+
+
+
+
+
+## [0.50.6](https://github.com/OHIF/Viewers/compare/@ohif/extension-dicom-html@0.50.5...@ohif/extension-dicom-html@0.50.6) (2019-09-10)
+
+
+### Bug Fixes
+
+* simplify runtime-extension usage ([ac5dbda](https://github.com/OHIF/Viewers/commit/ac5dbda))
+
+
+
+
+
+## [0.50.5](https://github.com/OHIF/Viewers/compare/@ohif/extension-dicom-html@0.50.4...@ohif/extension-dicom-html@0.50.5) (2019-09-09)
+
+**Note:** Version bump only for package @ohif/extension-dicom-html
+
+
+
+
+
+## [0.50.4](https://github.com/OHIF/Viewers/compare/@ohif/extension-dicom-html@0.50.3...@ohif/extension-dicom-html@0.50.4) (2019-09-06)
+
+
+### Bug Fixes
+
+* set NODE_ENV for production build ([9120db4](https://github.com/OHIF/Viewers/commit/9120db4))
+
+
+
+
+
+## [0.50.3](https://github.com/OHIF/Viewers/compare/@ohif/extension-dicom-html@0.50.2...@ohif/extension-dicom-html@0.50.3) (2019-09-04)
+
+**Note:** Version bump only for package @ohif/extension-dicom-html
+
+
+
+
+
+## [0.50.2](https://github.com/OHIF/Viewers/compare/@ohif/extension-dicom-html@0.50.1...@ohif/extension-dicom-html@0.50.2) (2019-09-04)
+
+
+### Bug Fixes
+
+* measurementsAPI issue caused by production build ([#842](https://github.com/OHIF/Viewers/issues/842)) ([49d3439](https://github.com/OHIF/Viewers/commit/49d3439))
+
+
+
+
+
+## [0.50.1](https://github.com/OHIF/Viewers/compare/@ohif/extension-dicom-html@0.50.0-alpha.10...@ohif/extension-dicom-html@0.50.1) (2019-08-14)
+
+**Note:** Version bump only for package @ohif/extension-dicom-html
+
+
+
+
+
+# [0.50.0-alpha.10](https://github.com/OHIF/Viewers/compare/@ohif/extension-dicom-html@0.0.4-alpha.9...@ohif/extension-dicom-html@0.50.0-alpha.10) (2019-08-14)
+
+**Note:** Version bump only for package @ohif/extension-dicom-html
+
+
+
+
+
+## [0.0.4-alpha.9](https://github.com/OHIF/Viewers/compare/@ohif/extension-dicom-html@0.0.4-alpha.8...@ohif/extension-dicom-html@0.0.4-alpha.9) (2019-08-14)
+
+**Note:** Version bump only for package @ohif/extension-dicom-html
+
+
+
+
+
+## 0.0.4-alpha.8 (2019-08-14)
+
+**Note:** Version bump only for package @ohif/extension-dicom-html
+
+
+
+
+
+# Change Log
+
+All notable changes to this project will be documented in this file. See
+[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## [0.0.4-alpha.7](https://github.com/OHIF/Viewers/compare/@ohif/extension-dicom-html@0.0.4-alpha.6...@ohif/extension-dicom-html@0.0.4-alpha.7) (2019-08-08)
+
+**Note:** Version bump only for package @ohif/extension-dicom-html
+
+# Change Log
+
+All notable changes to this project will be documented in this file. See
+[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## [0.0.4-alpha.6](https://github.com/OHIF/Viewers/compare/@ohif/extension-dicom-html@0.0.4-alpha.5...@ohif/extension-dicom-html@0.0.4-alpha.6) (2019-08-08)
+
+**Note:** Version bump only for package @ohif/extension-dicom-html
+
+# Change Log
+
+All notable changes to this project will be documented in this file. See
+[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## [0.0.4-alpha.5](https://github.com/OHIF/Viewers/compare/@ohif/extension-dicom-html@0.0.4-alpha.4...@ohif/extension-dicom-html@0.0.4-alpha.5) (2019-08-08)
+
+**Note:** Version bump only for package @ohif/extension-dicom-html
+
+# Change Log
+
+All notable changes to this project will be documented in this file. See
+[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## [0.0.4-alpha.4](https://github.com/OHIF/Viewers/compare/@ohif/extension-dicom-html@0.0.4-alpha.3...@ohif/extension-dicom-html@0.0.4-alpha.4) (2019-08-08)
+
+**Note:** Version bump only for package @ohif/extension-dicom-html
+
+# Change Log
+
+All notable changes to this project will be documented in this file. See
+[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## [0.0.4-alpha.3](https://github.com/OHIF/Viewers/compare/@ohif/extension-dicom-html@0.0.4-alpha.2...@ohif/extension-dicom-html@0.0.4-alpha.3) (2019-08-08)
+
+**Note:** Version bump only for package @ohif/extension-dicom-html
+
+# Change Log
+
+All notable changes to this project will be documented in this file. See
+[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## [0.0.4-alpha.2](https://github.com/OHIF/Viewers/compare/@ohif/extension-dicom-html@0.0.4-alpha.1...@ohif/extension-dicom-html@0.0.4-alpha.2) (2019-08-07)
+
+**Note:** Version bump only for package @ohif/extension-dicom-html
+
+## [0.0.4-alpha.1](https://github.com/OHIF/Viewers/compare/@ohif/extension-dicom-html@0.0.4-alpha.0...@ohif/extension-dicom-html@0.0.4-alpha.1) (2019-08-07)
+
+**Note:** Version bump only for package @ohif/extension-dicom-html
+
+## 0.0.4-alpha.0 (2019-08-05)
+
+**Note:** Version bump only for package @ohif/extension-dicom-html

--- a/extensions/dicom-html/LICENSE
+++ b/extensions/dicom-html/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 Open Health Imaging Foundation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/extensions/dicom-html/README.md
+++ b/extensions/dicom-html/README.md
@@ -1,0 +1,3 @@
+# @ohif/extension-dicom-html
+
+This is a v3 ported version of the same Extension in v2.

--- a/extensions/dicom-html/app.css
+++ b/extensions/dicom-html/app.css
@@ -1,0 +1,1 @@
+:root{--text-color-primary:#fff}.DicomHtmlViewport{padding:20px;overflow-y:scroll;width:100%;height:100%;color:#fff;color:var(--text-color-primary)}

--- a/extensions/dicom-html/package.json
+++ b/extensions/dicom-html/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@radicalimaging/extension-dicom-html",
+  "version": "3.0.0",
+  "description": "OHIF extension for rendering structured reports to HTML",
+  "author": "OHIF",
+  "license": "MIT",
+  "repository": "OHIF/Viewers",
+  "main": "dist/index.umd.js",
+  "module": "src/index.tsx",
+  "engines": {
+    "node": ">=14",
+    "npm": ">=6",
+    "yarn": ">=1.16.0"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "dev": "cross-env NODE_ENV=development webpack --config .webpack/webpack.dev.js --watch --debug --output-pathinfo",
+    "dev:dicom-html": "yarn run dev",
+    "build": "cross-env NODE_ENV=production webpack --config .webpack/webpack.prod.js",
+    "build:package": "yarn run build",
+    "prepublishOnly": "yarn run build",
+    "start": "yarn run dev"
+  },
+  "peerDependencies": {
+    "@ohif/core": "^3.0.0",
+    "@ohif/ui": "^2.0.0",
+    "dcmjs": "^0.24.10",
+    "dicom-parser": "^1.8.9",
+    "hammerjs": "^2.0.8",
+    "prop-types": "^15.6.2",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2"
+  },
+  "dependencies": {
+    "@babel/runtime": "^7.5.5"
+  }
+}

--- a/extensions/dicom-html/src/getSopClassHandlerModule.ts
+++ b/extensions/dicom-html/src/getSopClassHandlerModule.ts
@@ -1,0 +1,80 @@
+import { SOPClassHandlerName, SOPClassHandlerId } from './id';
+import { utils } from '@ohif/core';
+
+// TODO: Should probably use dcmjs for this
+const SOP_CLASS_UIDS = {
+  BASIC_TEXT_SR: '1.2.840.10008.5.1.4.1.1.88.11',
+  ENHANCED_SR: '1.2.840.10008.5.1.4.1.1.88.22',
+  COMPREHENSIVE_SR: '1.2.840.10008.5.1.4.1.1.88.33',
+  COMPREHENSIVE_3D_SR: '1.2.840.10008.5.1.4.1.1.88.34',
+  PROCEDURE_LOG_STORAGE: '1.2.840.10008.5.1.4.1.1.88.40',
+  MAMMOGRAPHY_CAD_SR: '1.2.840.10008.5.1.4.1.1.88.50',
+  CHEST_CAD_SR: '1.2.840.10008.5.1.4.1.1.88.65',
+  X_RAY_RADIATION_DOSE_SR: '1.2.840.10008.5.1.4.1.1.88.67',
+  ACQUISITION_CONTEXT_SR_STORAGE: '1.2.840.10008.5.1.4.1.1.88.71',
+};
+
+const sopClassUids = Object.values(SOP_CLASS_UIDS);
+
+function _getDisplaySetsFromSeries(
+  instances,
+  servicesManager,
+  extensionManager
+) {
+  // If the series has no instances, stop here
+  if (!instances || !instances.length) {
+    throw new Error('No instances were provided');
+  }
+
+  const instance = instances[0];
+
+  const {
+    StudyInstanceUID,
+    SeriesInstanceUID,
+    SOPInstanceUID,
+    SeriesDescription,
+    SeriesNumber,
+    SeriesDate,
+    ConceptNameCodeSequence,
+  } = instance;
+
+  const srDisplaySet = {
+    Modality: 'SR',
+    displaySetInstanceUID: utils.guid(),
+    SeriesDescription,
+    SeriesNumber,
+    SeriesDate,
+    SOPInstanceUID,
+    SeriesInstanceUID,
+    StudyInstanceUID,
+    SOPClassHandlerId,
+    referencedImages: null,
+    measurements: null,
+    isDerivedDisplaySet: true,
+    isLoaded: false,
+    sopClassUids,
+    instance,
+  };
+
+  return [srDisplaySet];
+}
+
+function getSopClassHandlerModule({ servicesManager, extensionManager }) {
+  const getDisplaySetsFromSeries = instances => {
+    return _getDisplaySetsFromSeries(
+      instances,
+      servicesManager,
+      extensionManager
+    );
+  };
+
+  return [
+    {
+      name: SOPClassHandlerName,
+      sopClassUids,
+      getDisplaySetsFromSeries,
+    },
+  ];
+}
+
+export default getSopClassHandlerModule;

--- a/extensions/dicom-html/src/id.js
+++ b/extensions/dicom-html/src/id.js
@@ -1,0 +1,8 @@
+import packageJson from '../package.json';
+
+const id = packageJson.name;
+
+const SOPClassHandlerName = 'dicom-html';
+const SOPClassHandlerId = `${id}.sopClassHandlerModule.${SOPClassHandlerName}`;
+
+export { SOPClassHandlerName, SOPClassHandlerId, id };

--- a/extensions/dicom-html/src/index.tsx
+++ b/extensions/dicom-html/src/index.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import getSopClassHandlerModule from './getSopClassHandlerModule';
+
+import { id } from './id.js';
+
+const Component = React.lazy(() => {
+  return import('./viewports/OHIFDicomHtmlViewport');
+});
+
+const OHIFDicomHtmlViewport = props => {
+  return (
+    <React.Suspense fallback={<div>Loading...</div>}>
+      <Component {...props} />
+    </React.Suspense>
+  );
+};
+
+export default {
+  /**
+   * Only required property. Should be a unique value across all extensions.
+   */
+  id,
+
+  getViewportModule({ servicesManager, extensionManager }) {
+    const ExtendedOHIFDicomHtmlViewport = props => {
+      return (
+        <OHIFDicomHtmlViewport
+          servicesManager={servicesManager}
+          extensionManager={extensionManager}
+          {...props}
+        />
+      );
+    };
+
+    return [{ name: 'dicom-html', component: ExtendedOHIFDicomHtmlViewport }];
+  },
+
+  getSopClassHandlerModule,
+};

--- a/extensions/dicom-html/src/viewports/DicomHtmlViewport.css
+++ b/extensions/dicom-html/src/viewports/DicomHtmlViewport.css
@@ -1,0 +1,36 @@
+:root {
+  --text-color-primary: white;
+}
+
+.DicomHtmlViewport {
+  padding: 20px;
+  overflow-y: scroll;
+  width: 100%;
+  height: 100%;
+  color: var(--text-color-primary);
+}
+
+.DicomHtmlViewport h1 {
+  font-size: 1.8em;
+  margin-top: 1em;
+}
+.DicomHtmlViewport h2 {
+  font-size: 1.5em;
+  margin-top: 0.75em;
+}
+.DicomHtmlViewport h3 {
+  font-size: 1.24em;
+  margin-top: 0.5em;
+}
+.DicomHtmlViewport h4 {
+  font-size: 1.1em;
+  margin-top: 0.3em;
+}
+.DicomHtmlViewport h5 {
+  font-size: 0.9em;
+  margin-top: 0.2em;
+}
+.DicomHtmlViewport h6 {
+  font-size: 0.75em;
+  margin-top: 0.1em;
+}

--- a/extensions/dicom-html/src/viewports/DicomHtmlViewport.tsx
+++ b/extensions/dicom-html/src/viewports/DicomHtmlViewport.tsx
@@ -1,0 +1,187 @@
+import React from 'react';
+
+import './DicomHtmlViewport.css';
+
+function normalizeString(str) {
+  return (str || '').replaceAll('^', ' ');
+}
+
+function getRelationshipString(data) {
+  switch (data.RelationshipType) {
+    case 'HAS CONCEPT MOD':
+      return 'Concept modifier: ';
+    case 'HAS OBS CONTEXT':
+      return 'Observation context: ';
+    default:
+      return '';
+  }
+}
+
+const getMeaningString = data => {
+  if (data.ConceptNameCodeSequence) {
+    const { CodeMeaning } = data.ConceptNameCodeSequence;
+
+    return `${CodeMeaning} = `;
+  }
+
+  return '';
+};
+
+function getValueString(data) {
+  switch (data.ValueType) {
+    case 'CODE':
+      const {
+        CodeMeaning,
+        CodeValue,
+        CodingSchemeDesignator,
+      } = data.ConceptNameCodeSequence[0];
+
+      return `${CodeMeaning} (${CodeValue}, ${CodingSchemeDesignator})`;
+
+    case 'PNAME':
+      console.log(data);
+      return normalizeString(
+        data.PersonName[0] ? data.PersonName[0].Alphabetic : data.PersonName
+      );
+
+    case 'TEXT':
+      return normalizeString(data.TextValue);
+
+    case 'UIDREF':
+      return data.UID;
+
+    case 'NUM':
+      const { MeasuredValueSequence } = data;
+      const numValue = MeasuredValueSequence.NumericValue;
+      const codeValue =
+        MeasuredValueSequence.MeasurementUnitsCodeSequence.CodeValue;
+      return `${numValue} ${codeValue}`;
+  }
+}
+
+function constructPlainValue(data) {
+  const value = getValueString(data);
+
+  if (value) {
+    return getRelationshipString(data) + getMeaningString(data) + value;
+  }
+}
+
+function getMainData(data) {
+  const root = [];
+
+  const patientValue = normalizeString(
+    `${data.PatientName[0].Alphabetic} (${data.PatientSex}, #${data.PatientID})`
+  );
+  root.push(getMainDataItem('Patient', patientValue));
+
+  const studyValue = normalizeString(data.StudyDescription);
+  root.push(getMainDataItem('Study', studyValue));
+
+  const seriesValue = normalizeString(
+    `${data.SeriesDescription} (#${data.SeriesNumber})`
+  );
+  root.push(getMainDataItem('Series', seriesValue));
+
+  const manufacturerValue = normalizeString(
+    `${data.Manufacturer} (${data.ManufacturerModelName}, #${data.DeviceSerialNumber})`
+  );
+
+  root.push(getMainDataItem('Manufacturer', manufacturerValue));
+
+  const mainDataObjects = {
+    CompletionFlag: 'Completion flag',
+    VerificationFlag: 'Verification flag',
+  };
+
+  Object.keys(mainDataObjects).forEach(key => {
+    if (!data[key]) {
+      return;
+    }
+
+    const item = getMainDataItem(mainDataObjects[key], data[key]);
+
+    root.push(item);
+  });
+
+  // TODO: Format these dates
+  const contentDateTimeValue = `${data.ContentDate} ${data.ContentTime}`;
+  root.push(getMainDataItem('Content Date/Time', contentDateTimeValue));
+
+  root.push();
+
+  return <div>{root}</div>;
+}
+
+const getContentSequence = (data, level = 1) => {
+  const root = [];
+  if (data.ValueType) {
+    if (data.ValueType === 'CONTAINER') {
+      if (!data.ConceptNameCodeSequence) console.log(data);
+      else {
+        const { CodeMeaning, CodeValue, CodingSchemeDesignator } =
+          data.ConceptNameCodeSequence[0] || data.ConceptNameCodeSequence;
+
+        const header = `${CodeMeaning} (${CodeValue} - ${CodingSchemeDesignator})`;
+        const HeaderDynamicLevel = `h${Math.min(level, 6)}`;
+        root.push(
+          <HeaderDynamicLevel key={header}>{header}</HeaderDynamicLevel>
+        );
+      }
+
+      data.ContentSequence.map(item => getContentSequence(item, level + 1))
+        .filter(item => item)
+        .forEach(item => root.push(item));
+    }
+
+    root.push(constructPlainValue(data));
+  }
+
+  if (data.ContentSequence) {
+    data.ContentSequence.map(item => getContentSequence(item, level + 1))
+      .filter(item => item)
+      .forEach(item => root.push(item));
+  }
+
+  return <div>{root}</div>;
+};
+
+function getMainDataItem(key, value) {
+  return (
+    <div key={key}>
+      <b>{key}</b>: {value}
+    </div>
+  );
+}
+
+function DicomHtmlViewport(props) {
+  const mainData = getMainData(props.instance);
+  const contentSequence = getContentSequence(props.instance);
+  const content = (
+    <>
+      {mainData}
+      {contentSequence}
+    </>
+  );
+
+  const setViewportActiveHandler = () => {
+    const { setViewportActive, viewportIndex, activeViewportIndex } = props;
+
+    if (viewportIndex !== activeViewportIndex) {
+      setViewportActive(viewportIndex);
+    }
+  };
+
+  return (
+    <div
+      data-cy="dicom-html-viewport"
+      className="DicomHtmlViewport"
+      onClick={setViewportActiveHandler}
+      onScroll={setViewportActiveHandler}
+    >
+      {content}
+    </div>
+  );
+}
+
+export default DicomHtmlViewport;

--- a/extensions/dicom-html/src/viewports/OHIFDicomHtmlViewport.tsx
+++ b/extensions/dicom-html/src/viewports/OHIFDicomHtmlViewport.tsx
@@ -1,0 +1,33 @@
+import React, { useEffect, useState } from 'react';
+import { DicomMetadataStore, utils } from '@ohif/core';
+import DicomHtmlViewport from './DicomHtmlViewport';
+
+function OHIFDicomHtmlViewport(props) {
+  const {
+    children,
+    dataSource,
+    displaySets,
+    viewportIndex,
+    servicesManager,
+    extensionManager,
+    commandsManager,
+  } = props;
+
+  const {
+    DisplaySetService,
+    CornerstoneViewportService,
+  } = servicesManager.services;
+
+  return (
+    <>
+      <DicomHtmlViewport
+        instance={displaySets[0].instance}
+        viewportIndex={viewportIndex}
+        activeViewportIndex={props.activeViewportIndex}
+        setViewportActive={viewportIndex => {}}
+      />
+    </>
+  );
+}
+
+export default OHIFDicomHtmlViewport;


### PR DESCRIPTION
Port of dicom-html extension of OHIFv2 to OHIF v3.

OHIF v3 has cornerstone-dicom-sr extension to deal with SRs.
But this focuses on Measurement SRs, and do not support text-only reports.

On the other hand, dicom-html focuses on text-based reports.

NOTE: for now, two extensions are not compatible, and should not be used within the same mode.