### PR TITLE
feat:Extend default routes with html route only if html loaded

### DIFF
--- a/extensions/dicom-html/src/index.tsx
+++ b/extensions/dicom-html/src/index.tsx
@@ -1,11 +1,28 @@
 import React from 'react';
 import getSopClassHandlerModule from './getSopClassHandlerModule';
+import {defaultRoutes, sopClassHandlers} from '@radicalimaging/config-mode';
 
 import { id } from './id.js';
 
 const Component = React.lazy(() => {
   return import('./viewports/OHIFDicomHtmlViewport');
 });
+
+export const dicomhtml = {
+  sopClassHandler:
+    '@radicalimaging/extension-dicom-html.sopClassHandlerModule.dicom-html',
+  viewport: '@radicalimaging/extension-dicom-html.viewportModule.dicom-html',
+};
+
+// Add the html route as a default route
+defaultRoutes[0].defaultRoutes.props.viewports.push(
+  {
+    namespace: dicomhtml.viewport,
+    displaySetsToDisplay: [dicomhtml.sopClassHandler],
+  },
+);
+
+sopClassHandlers.push(dicomhtml.sopClassHandler);
 
 const OHIFDicomHtmlViewport = props => {
   return (

--- a/ohif-configurable/config-mode/src/defaultRoutes.ts
+++ b/ohif-configurable/config-mode/src/defaultRoutes.ts
@@ -15,36 +15,37 @@ import {ohif, cornerstone, dicomsr, dicomvideo, dicompdf, dicomseg} from "./exte
 const defaultRoutes = [
   {
     path: 'template',
-    layoutTemplate: ({ location, servicesManager }) => {
-      return {
-        id: ohif.layout,
-        props: {
-          leftPanels: [ohif.leftPanel],
-          rightPanels: [ohif.rightPanel, dicomseg.panel,],
-          viewports: [
-            {
-              namespace: cornerstone.viewport,
-              displaySetsToDisplay: [ohif.sopClassHandler],
-            },
-            {
-              namespace: dicomsr.viewport,
-              displaySetsToDisplay: [dicomsr.sopClassHandler],
-            },
-            {
-              namespace: dicomvideo.viewport,
-              displaySetsToDisplay: [dicomvideo.sopClassHandler],
-            },
-            {
-              namespace: dicompdf.viewport,
-              displaySetsToDisplay: [dicompdf.sopClassHandler],
-            },
-            {
-              namespace: dicomseg.viewport,
-              displaySetsToDisplay: [dicomseg.sopClassHandler],
-            },
-          ],
-        },
-      };
+    defaultRoutes: {
+      id: ohif.layout,
+      props: {
+        leftPanels: [ohif.leftPanel],
+        rightPanels: [ohif.rightPanel, dicomseg.panel,],
+        viewports: [
+          {
+            namespace: cornerstone.viewport,
+            displaySetsToDisplay: [ohif.sopClassHandler],
+          },
+          {
+            namespace: dicomsr.viewport,
+            displaySetsToDisplay: [dicomsr.sopClassHandler],
+          },
+          {
+            namespace: dicomvideo.viewport,
+            displaySetsToDisplay: [dicomvideo.sopClassHandler],
+          },
+          {
+            namespace: dicompdf.viewport,
+            displaySetsToDisplay: [dicompdf.sopClassHandler],
+          },
+          {
+            namespace: dicomseg.viewport,
+            displaySetsToDisplay: [dicomseg.sopClassHandler],
+          },
+        ],
+      },
+    },
+    layoutTemplate({ location, servicesManager }) {
+      return this.defaultRoutes;
     },
   },
 ];

--- a/ohif-configurable/config-mode/src/extensions.ts
+++ b/ohif-configurable/config-mode/src/extensions.ts
@@ -10,6 +10,15 @@ export const cornerstone = {
   viewport: '@ohif/extension-cornerstone.viewportModule.cornerstone',
 };
 
+
+export const tracked = {
+  measurements:
+    '@ohif/extension-measurement-tracking.panelModule.trackedMeasurements',
+  thumbnailList: '@ohif/extension-measurement-tracking.panelModule.seriesList',
+  viewport:
+    '@ohif/extension-measurement-tracking.viewportModule.cornerstone-tracked',
+};
+
 export const dicomsr = {
   sopClassHandler:
     '@ohif/extension-cornerstone-dicom-sr.sopClassHandlerModule.dicom-sr',

--- a/ohif-configurable/config-mode/src/onModeExit.ts
+++ b/ohif-configurable/config-mode/src/onModeExit.ts
@@ -7,19 +7,19 @@ const onModeExit = ({ servicesManager }) => {
     ToolBarService,
     SegmentationService,
     CornerstoneViewportService,
-    HangingProtocolService,
     customizationService,
   } = servicesManager.services;
 
-  console.log("**** onModeExit config mode being called");
-  ToolBarService.reset();
-  MeasurementService.clearMeasurements();
-  customizationService.reset();
-  ToolGroupService.destroy();
-  SyncGroupService.destroy();
-  SegmentationService.destroy();
-  CornerstoneViewportService.destroy();
-  HangingProtocolService.reset();
+  try {
+    ToolBarService.reset();
+    customizationService.reset();
+    ToolGroupService.destroy();
+    SyncGroupService.destroy();
+    SegmentationService.destroy();
+    CornerstoneViewportService.destroy();
+  } catch (e) {
+    console.warn("* onModeExit failed", e);
+  }
 };
 
 export default onModeExit;

--- a/ohif-configurable/findings-mode/.webpack/webpack.prod.js
+++ b/ohif-configurable/findings-mode/.webpack/webpack.prod.js
@@ -44,6 +44,12 @@ const config = {
         commonjs: 'classnames',
         amd: 'classnames',
       },
+      '@radicalimaging/config-mode': {
+        root: '@radicalimaging/config-mode',
+        commonjs2: '@radicalimaging/config-mode',
+        commonjs: '@radicalimaging/config-mode',
+        amd: '@radicalimaging/config-mode',
+      },
       'react-router-dom': {
         root: 'react-router-dom',
         commonjs2: 'react-router-dom',

--- a/ohif-configurable/hp-extension/src/synchronizers/initialZoomPanCallback.ts
+++ b/ohif-configurable/hp-extension/src/synchronizers/initialZoomPanCallback.ts
@@ -67,9 +67,8 @@ export default function initialPanZoomCallback(
 export function storeCurrentZoomPan(synchronizerInstance: Synchronizer, viewportInfo: Types.IViewportId) {
   const renderingEngine = getRenderingEngine(viewportInfo.renderingEngineId);
   if (!renderingEngine) {
-    throw new Error(
-      `No RenderingEngine for Id: ${viewportInfo.renderingEngineId}`
-    );
+    console.log("No RenderingEngine for Id:",viewportInfo.renderingEngineId);
+    return;
   }
 
   const { viewportId } = viewportInfo;


### PR DESCRIPTION
This change allows viewing html reports alongside annotation/markup SR objects