### PR TITLE
feat: Compatibility with new hp/toolbar buttons only

### DIFF
--- a/modes/veterinary-mode/package.json
+++ b/modes/veterinary-mode/package.json
@@ -31,7 +31,7 @@
   "peerDependencies": {
     "@ohif/core": "^3.0.0",
     "@radicalimaging/config-mode": "^3.4.2",
-    "@radicalimaging/findings-mode": "^3.4.2"
+    "@radicalimaging/findings-mode": "^3.13.4"
   },
   "dependencies": {
     "@babel/runtime": "7.17.9"

--- a/ohif-configurable/config-mode/package.json
+++ b/ohif-configurable/config-mode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@radicalimaging/config-mode",
-  "version": "3.13.4",
+  "version": "3.13.5",
   "description": "A configurable/themeable mode that allows runtime extensions to the mode.",
   "author": "Radical Imaging",
   "license": "MIT",

--- a/ohif-configurable/config-mode/package.json
+++ b/ohif-configurable/config-mode/package.json
@@ -33,7 +33,7 @@
     "test:unit:ci": "jest --ci --runInBand --collectCoverage --passWithNoTests"
   },
   "peerDependencies": {
-    "@cornerstonejs/tools": "^0.67.7",
+    "@cornerstonejs/tools": "^1.1.0",
     "@ohif/core": "^3.0.0",
     "@ohif/ui": "^1.10.10",
     "gl-matrix": "^3.4.3",

--- a/ohif-configurable/config-mode/package.json
+++ b/ohif-configurable/config-mode/package.json
@@ -33,7 +33,7 @@
     "test:unit:ci": "jest --ci --runInBand --collectCoverage --passWithNoTests"
   },
   "peerDependencies": {
-    "@cornerstonejs/tools": "^1.1.0",
+    "@cornerstonejs/tools": "^1.11.2",
     "@ohif/core": "^3.0.0",
     "@ohif/ui": "^1.10.10",
     "gl-matrix": "^3.4.3",

--- a/ohif-configurable/config-mode/package.json
+++ b/ohif-configurable/config-mode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@radicalimaging/config-mode",
-  "version": "3.13.2",
+  "version": "3.13.4",
   "description": "A configurable/themeable mode that allows runtime extensions to the mode.",
   "author": "Radical Imaging",
   "license": "MIT",
@@ -33,7 +33,7 @@
     "test:unit:ci": "jest --ci --runInBand --collectCoverage --passWithNoTests"
   },
   "peerDependencies": {
-    "@cornerstonejs/tools": "^0.63.3",
+    "@cornerstonejs/tools": "^0.67.7",
     "@ohif/core": "^3.0.0",
     "@ohif/ui": "^1.10.10",
     "gl-matrix": "^3.4.3",

--- a/ohif-configurable/config-mode/src/onModeEnter.ts
+++ b/ohif-configurable/config-mode/src/onModeEnter.ts
@@ -1,8 +1,9 @@
-export default function onModeEnter({ servicesManager, extensionManager, commandsManager }) {
+export default function onModeEnter(props) {
+  const { servicesManager, extensionManager, commandsManager } = props;
   const {
     measurementService,
-    ToolBarService,
-    ToolGroupService,
+    toolbarService,
+    toolGroupService,
     customizationService,
   } = servicesManager.services;
 
@@ -15,7 +16,8 @@ export default function onModeEnter({ servicesManager, extensionManager, command
   let unsubscribe;
 
   const activateTool = () => {
-    ToolBarService.recordInteraction(this.defaultTool);
+    toolbarService.recordInteraction(this.defaultTool);
+    this.activateOtherTools?.(props);
 
     // We don't need to reset the active tool whenever a viewport is getting
     // added to the toolGroup.
@@ -24,15 +26,15 @@ export default function onModeEnter({ servicesManager, extensionManager, command
 
   // Since we only have one viewport for the basic cs3d mode and it has
   // only one hanging protocol, we can just use the first viewport
-  ({ unsubscribe } = ToolGroupService.subscribe(
-    ToolGroupService.EVENTS.VIEWPORT_ADDED,
+  ({ unsubscribe } = toolGroupService.subscribe(
+    toolGroupService.EVENTS.VIEWPORT_ADDED,
     activateTool
   ));
 
-  ToolBarService.init(extensionManager);
-  ToolBarService.addButtons(this.toolbarButtons);
+  toolbarService.init(extensionManager);
+  toolbarService.addButtons(this.toolbarButtons);
   Object.keys(this.toolBarSections).forEach(section => {
-    ToolBarService.createButtonSection(section, this.toolBarSections[section]);
+    toolbarService.createButtonSection(section, this.toolBarSections[section]);
   });
 
   customizationService?.addModeCustomizations?.(this.modeCustomizations);

--- a/ohif-configurable/config-mode/src/toolbarButtons.js
+++ b/ohif-configurable/config-mode/src/toolbarButtons.js
@@ -28,18 +28,6 @@ function _createButton(type, id, icon, label, commands, tooltip) {
   };
 }
 
-function _createCommands(commandName, toolName, toolGroupIds) {
-  return toolGroupIds.map(toolGroupId => ({
-    /* It's a command that is being run when the button is clicked. */
-    commandName,
-    commandOptions: {
-      toolName,
-      toolGroupId,
-    },
-    context: 'CORNERSTONE',
-  }));
-}
-
 const _createActionButton = _createButton.bind(null, 'action');
 const _createToggleButton = _createButton.bind(null, 'toggle');
 const _createToolButton = _createButton.bind(null, 'tool');
@@ -384,7 +372,6 @@ const toolbarButtons = [
   // ************ New Layout Section
   
     // Measurement
-    isNewHP ? 
   {
     id: 'Layout',
       type: 'ohif.splitButton',
@@ -478,15 +465,7 @@ const toolbarButtons = [
           },
         ],
       },
-    } :
-    {
-      id: 'Layout',
-    type: 'ohif.layoutSelector',
-    props: {
-      rows: 3,
-      columns: 3,
     },
-  },
   
   {
     id: 'MPR',
@@ -698,4 +677,5 @@ const toolbarButtons = [
   },
 ];
 
+console.log("* config-mode toolbarButtons", toolbarButtons);
 export default toolbarButtons;

--- a/ohif-configurable/config-mode/src/toolbarButtons.js
+++ b/ohif-configurable/config-mode/src/toolbarButtons.js
@@ -6,8 +6,9 @@ import {
   WindowLevelMenuItem,
 } from '@ohif/ui';
 import { defaults } from '@ohif/core';
+import { EVENTS } from '@cornerstonejs/core';
 
-const isNewHP = window.config.isNewHP;
+console.log("EVENTS=", EVENTS);
 
 const { windowLevelPresets } = defaults;
 /**
@@ -17,7 +18,7 @@ const { windowLevelPresets } = defaults;
  * @param {*} icon
  * @param {*} label
  */
-function _createButton(type, id, icon, label, commands, tooltip) {
+function _createButton(type, id, icon, label, commands, tooltip, extraOptions) {
   return {
     id,
     icon,
@@ -25,12 +26,41 @@ function _createButton(type, id, icon, label, commands, tooltip) {
     type,
     commands,
     tooltip,
+    ...extraOptions,
   };
 }
 
 const _createActionButton = _createButton.bind(null, 'action');
 const _createToggleButton = _createButton.bind(null, 'toggle');
 const _createToolButton = _createButton.bind(null, 'tool');
+
+const ReferenceLinesCommands = [
+  {
+    commandName: 'setSourceViewportForReferenceLinesTool',
+    context: 'CORNERSTONE',
+  },
+  {
+    commandName: 'setToolActive',
+    commandOptions: {
+      toolName: 'ReferenceLines',
+    },
+    context: 'CORNERSTONE',
+  },
+];
+
+const ReferenceLines = _createToggleButton(
+  'ReferenceLines',
+  'tool-referenceLines', // change this with the new icon
+  'Reference Lines',
+  ReferenceLinesCommands,
+  'Show reference lines',
+  {
+    listeners: {
+      activeViewportIdChanged: ReferenceLinesCommands,
+      [EVENTS.STACK_VIEWPORT_NEW_STACK]: ReferenceLinesCommands,
+    },
+  }
+);
 
 /**
  *
@@ -575,6 +605,7 @@ const toolbarButtons = [
             context: 'CORNERSTONE',
           },
         ]),
+        ReferenceLines,
         _createToggleButton(
           'ReferenceLines',
           'tool-referenceLines', // change this with the new icon

--- a/ohif-configurable/findings-mode/package.json
+++ b/ohif-configurable/findings-mode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@radicalimaging/findings-mode",
-  "version": "3.13.3",
+  "version": "3.13.4",
   "description": "Support context menu/command key findings",
   "author": "Bill Wallace, Radical Imaging",
   "license": "MIT",

--- a/ohif-configurable/hp-extension/package.json
+++ b/ohif-configurable/hp-extension/package.json
@@ -30,7 +30,7 @@
     "start": "yarn run dev"
   },
   "peerDependencies": {
-    "@cornerstonejs/tools": "^0.63.3",
+    "@cornerstonejs/tools": "^0.67.7",
     "@ohif/core": "^3.0.0",
     "@ohif/extension-cornerstone": "^3.0.0",
     "@ohif/extension-default": "^3.0.0",

--- a/ohif-configurable/hp-extension/package.json
+++ b/ohif-configurable/hp-extension/package.json
@@ -30,7 +30,7 @@
     "start": "yarn run dev"
   },
   "peerDependencies": {
-    "@cornerstonejs/tools": "^0.67.7",
+    "@cornerstonejs/tools": "^1.1.0",
     "@ohif/core": "^3.0.0",
     "@ohif/extension-cornerstone": "^3.0.0",
     "@ohif/extension-default": "^3.0.0",

--- a/ohif-configurable/hp-extension/package.json
+++ b/ohif-configurable/hp-extension/package.json
@@ -30,7 +30,7 @@
     "start": "yarn run dev"
   },
   "peerDependencies": {
-    "@cornerstonejs/tools": "^1.1.0",
+    "@cornerstonejs/tools": "^1.11.2",
     "@ohif/core": "^3.0.0",
     "@ohif/extension-cornerstone": "^3.0.0",
     "@ohif/extension-default": "^3.0.0",


### PR DESCRIPTION
This change removes the check of isNewHP, as that is now fairly old, and we can just default to being compatible